### PR TITLE
Ordering for uploaded KMLs

### DIFF
--- a/ui/src/elements/ngm-side-bar.ts
+++ b/ui/src/elements/ngm-side-bar.ts
@@ -747,8 +747,9 @@ export class SideBar extends LitElementI18n {
     if (!this.viewer) return;
     const dataSource = new CustomDataSource();
     const name = await parseKml(this.viewer, file, dataSource, clampToGround);
+    const layer = `${name.replace(' ', '_')}_${Date.now()}`;
     // name used as id for datasource
-    dataSource.name = `${name}_${Date.now()}`;
+    dataSource.name = layer;
     MainStore.addUploadedKmlName(dataSource.name);
     await this.viewer.dataSources.add(dataSource);
     await renderWithDelay(this.viewer);
@@ -757,6 +758,7 @@ export class SideBar extends LitElementI18n {
     const config: LayerConfig = {
       load() {return promise;},
       label: name,
+      layer,
       promise: promise,
       zoomToBbox: true,
       opacity: DEFAULT_LAYER_OPACITY,

--- a/ui/src/layers/LayersActions.ts
+++ b/ui/src/layers/LayersActions.ts
@@ -93,10 +93,13 @@ export default class LayersAction {
 
   async reorderLayers(newLayers: LayerConfig[]) {
     const imageries = this.viewer.scene.imageryLayers;
+    const dataSources = this.viewer.dataSources;
     for (const config of newLayers) {
-      if (config.type === LayerType.swisstopoWMTS) {
-        const imagery = await config.promise;
-        if (imagery instanceof ImageryLayer) imageries.raiseToTop(imagery);
+      const layer = await config.promise;
+      if (config.type === LayerType.swisstopoWMTS && layer instanceof ImageryLayer) {
+        imageries.raiseToTop(layer);
+      } else if (layer instanceof CustomDataSource && dataSources.contains(layer)) {
+        dataSources.raiseToTop(layer);
       }
     }
     syncLayersParam(newLayers);


### PR DESCRIPTION
Made ordering between uploaded KMLs work

1. Fixed ordering in the layers list by adding the `layer` property for uploaded layers
2. Added sorting in the viewer dataSources