### PR TITLE
Bug fixes

### DIFF
--- a/ui/src/elements/ngm-map-configuration.ts
+++ b/ui/src/elements/ngm-map-configuration.ts
@@ -31,7 +31,7 @@ export class NgmMapConfiguration extends LitElementI18n {
   accessor baseMapId = 'ch.swisstopo.pixelkarte-grau';
   @query('ngm-map-chooser')
   accessor mapChooserElement;
-  private debouncedOpacityUpdate = debounce((evt: Event) => this.updateOpacity(Number((<HTMLInputElement>evt.target).value)), 250, true);
+  private debouncedOpacityUpdate = debounce((evt: Event) => this.updateOpacity(Number((<HTMLInputElement>evt.target).value)), 250);
   private prevExaggeration: number = 1;
 
   constructor() {
@@ -170,7 +170,7 @@ export class NgmMapConfiguration extends LitElementI18n {
             <label>${(this.exaggeration).toFixed()}x</label>
           </div>
           <input type="range"
-                 class="ngm-slider ${classMap({'ngm-disabled': this.mapChooser!.selectedMap.id === 'empty_map'})}"
+                 class="ngm-slider"
                  style="background-image: linear-gradient(to right, var(--ngm-interaction-active), var(--ngm-interaction-active) ${this.exaggeration * 5}%, white ${this.exaggeration * 5}%)"
                  min=1 max=20 step=1
                  .value=${!isNaN(this.exaggeration) ? this.exaggeration : 1}

--- a/ui/src/elements/ngm-nadir-view.ts
+++ b/ui/src/elements/ngm-nadir-view.ts
@@ -68,8 +68,11 @@ export class NgmNadirView extends LitElementI18n {
   updateFromCamera() {
     if (!this.viewer) return;
     this.currentHeading = this.viewer.scene.camera.heading;
-    if (this.nadirActive && !CesiumMath.equalsEpsilon(this.viewer.scene.camera.pitch, -CesiumMath.PI_OVER_TWO, CesiumMath.EPSILON1)) {
+    const nadirView = CesiumMath.equalsEpsilon(this.viewer.scene.camera.pitch, -CesiumMath.PI_OVER_TWO, CesiumMath.EPSILON1);
+    if (this.nadirActive && !nadirView) {
       this.height = undefined;
+      this.toggleNadirStatus();
+    } else if (!this.nadirActive && nadirView) {
       this.toggleNadirStatus();
     }
     const angle = Math.round(this.currentHeading * 180 / Math.PI);

--- a/ui/src/layers/ngm-layers-sort.ts
+++ b/ui/src/layers/ngm-layers-sort.ts
@@ -33,7 +33,7 @@ export default class NgmLayersSort extends LitElementI18n {
                 const reverse = this.sortedList.reverse();
                 const movedLayers = reverse.filter(l => layerCodes.includes(l.layer));
                 const newLayers = reverse.filter(l => !layerCodes.includes(l.layer));
-                newLayers.splice(evt.newIndex, 0, ...movedLayers);
+                newLayers.splice(evt.newIndicies[0].index, 0, ...movedLayers);
                 this.sortedList = newLayers.reverse();
                 this.dispatchEvent(new CustomEvent('orderChanged', {detail: this.sortedList}));
             },

--- a/ui/src/toolbox/GeometryController.ts
+++ b/ui/src/toolbox/GeometryController.ts
@@ -216,9 +216,14 @@ export class GeometryController {
     const entity = this.geometriesDataSource!.entities.getById(id);
     if (!entity) return;
     NavToolsStore.hideTargetPoint();
+    const sliceGeom = ToolboxStore.sliceGeometry?.value;
     if (!entity.isShowing)
       entity.show = true;
     flyToGeom(this.viewer!.scene, entity);
+    if (sliceGeom && sliceGeom.id === id) {
+      entity.show = false;
+      return;
+    }
     this.pickGeometry(id);
   }
 


### PR DESCRIPTION
Fixes for:

- When more than one layer shifted, it always placed one position lower after ordering finished
- The first move of the opacity slider does nothing in the 3D view (when page reloaded)
- Exaggeration slider disabled when background layer is hidden by clicking on the eye icon
- Zoom to geometry that is used for slicing makes it visible during slicing
- Change the camera icon to a square box when the camera is in "perfect" nadir view