### PR TITLE
Use github repository to store Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,6 @@ jobs:
           node-version: 'lts/*'
           cache: npm
           cache-dependency-path: ui/package-lock.json
-      - name: Log into Docker hub
-        env:
-          DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
-          DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
-        run: |
-          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       - run: docker pull rust:1.63
       - name: Run local api tests
         run: make acceptance
@@ -48,18 +42,12 @@ jobs:
     steps:
       # - run: docker system prune --all --force --volumes
       - uses: actions/checkout@v4
-      - name: Log into Docker hub
-        env:
-          DOCKERHUB_USERNAME: ${{secrets.DOCKERHUB_USERNAME}}
-          DOCKERHUB_PASSWORD: ${{secrets.DOCKERHUB_PASSWORD}}
-        run: |
-          docker login -u $DOCKERHUB_USERNAME -p $DOCKERHUB_PASSWORD
       # Make sure we are building and deploying image with latest security fixes
       - run: docker pull rust:1.63
       - run: docker pull alpine:3.16
       - name: Build api
         run: make build_api
-      - name: Push to docker hub and deploy to dev
+      - name: Push to github packages and deploy to dev
         env:
           AWS_DEFAULT_REGION: ${{secrets.AWS_DEFAULT_REGION}}
           AWS_ACCESS_KEY_ID: ${{secrets.FARGATE_API_AWS_ACCESS_KEY_ID}}
@@ -68,7 +56,7 @@ jobs:
         run: |
           if [[ ${{github.ref}} == "refs/heads/master" ]]
           then
-            docker push camptocamp/swissgeol_api:latest
+            docker push ghcr.io/swisstopo/swissgeol-viewer-app-api:latest
             mkdir myspace
             chmod go-rwx myspace
             echo -n $NGM_ARGOCD_DEPLOYKEY | base64 -d > myspace/id_key

--- a/DEPLOY_VIEWER.md
+++ b/DEPLOY_VIEWER.md
@@ -52,7 +52,7 @@ see gopass
 ### Master (CI)
 
 - the UI is built and copied to S3;
-- the API is built, published to docker hub and deployed to the dev and reviews environments.
+- the API is built, published to github packages and deployed to the dev and reviews environments.
 
 This is handled in .github/workflows/ci.yml
 
@@ -73,6 +73,8 @@ export VERSION="" # the version (like 2022.02.0)
 git tag $VERSION -m $VERSION
 git push origin $VERSION
 scripts/release_ui.sh
+export CR_PAT=<your personal github access token (classic)>
+echo $CR_PAT | docker login ghcr.io -u <github login> --password-stdin
 scripts/release_api.sh # (on macos: scripts/release_api.sh mac
 ```
 
@@ -87,6 +89,8 @@ tmux new-session 'scripts/release_ui.sh; bash' \; split-window -h 'scripts/relea
 ```bash
 export VERSION="" # the version (like 2022.02.0)
 git checkout $VERSION
+export CR_PAT=<your personal github access token (classic)>
+echo $CR_PAT | docker login ghcr.io -u <github login> --password-stdin
 scripts/deploy_viewer.sh int
 ```
 
@@ -99,6 +103,8 @@ The version should have been created and tested on int first.
 ```bash
 export VERSION="" # the version (like 2022.02.0)
 git checkout $VERSION
+export CR_PAT=<your personal github access token (classic)>
+echo $CR_PAT | docker login ghcr.io -u <github login> --password-stdin
 scripts/deploy_viewer.sh prod
 ```
 Go to the [ArgoCD dashboard](#argocd) to check if everything went well.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 export DOCKER_TAG ?= latest
-export DOCKER_BASE = camptocamp/swissgeol
+export DOCKER_BASE = ghcr.io/swisstopo/swissgeol-viewer-app
 GIT_HASH := $(shell git rev-parse HEAD)
 UNAME_S := $(shell uname -s)
 
@@ -15,15 +15,15 @@ acceptance: build_local_api ui/node_modules/.timestamp
 .PHONY: build_local_api
 build_local_api:
 ifeq ($(UNAME_S),Darwin)
-	docker build -f api/DockerfileDevMac -t $(DOCKER_BASE)_local_api:latest --build-arg "GIT_HASH=$(GIT_HASH)" api --pull --platform=linux/amd64
+	docker build -f api/DockerfileDevMac -t $(DOCKER_BASE)-local_api:latest --build-arg "GIT_HASH=$(GIT_HASH)" api --pull --platform=linux/amd64
 else
-	docker build -f api/DockerfileDev -t $(DOCKER_BASE)_local_api:latest --build-arg "GIT_HASH=$(GIT_HASH)" api --pull
+	docker build -f api/DockerfileDev -t $(DOCKER_BASE)-local_api:latest --build-arg "GIT_HASH=$(GIT_HASH)" api --pull
 endif
 
 .PHONY: build_api
 build_api:
-	docker build --target builder -t $(DOCKER_BASE)_api_builder:latest --build-arg "GIT_HASH=$(GIT_HASH)" api --pull
-	docker build -t $(DOCKER_BASE)_api:latest --build-arg "GIT_HASH=$(GIT_HASH)" api
+	docker build --target builder -t $(DOCKER_BASE)-api_builder:latest --build-arg "GIT_HASH=$(GIT_HASH)" api --pull
+	docker build -t $(DOCKER_BASE)-api:latest --build-arg "GIT_HASH=$(GIT_HASH)" api
 
 ui/node_modules/.timestamp: ui/package-lock.json
 	cd ui; npm ci --no-audit --ignore-scripts

--- a/docker-compose-tests.yaml
+++ b/docker-compose-tests.yaml
@@ -1,7 +1,7 @@
 services:
   tests:
     init: true # handle kill signals for rust
-    image: camptocamp/swissgeol_local_api:latest
+    image: ghcr.io/swisstopo/swissgeol-viewer-app-local_api:latest
     platform: linux/amd64
     environment:
       PGUSER: www-data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   api:
     init: true # handle kill signals for rust
-    image: camptocamp/swissgeol_local_api:latest
+    image: ghcr.io/swisstopo/swissgeol-viewer-app-local_api:latest
     platform: linux/amd64
     ports:
       - 8480:3000

--- a/scripts/deploy-to-env.sh
+++ b/scripts/deploy-to-env.sh
@@ -15,7 +15,7 @@ fi
 function get_image_hash() {
   local svc="$1"
 
-  local IMAGE=$(echo camptocamp/$svc | tr [:upper:] [:lower:])
+  local IMAGE=$(echo ghcr.io/swisstopo/$svc | tr [:upper:] [:lower:])
   echo "docker inspect $IMAGE -f '{{ .RepoDigests }}'"
   local HASH=$(docker inspect $IMAGE -f '{{ .RepoDigests }}' | tr -d '[]' | tr " " "\n" | cut -d@ -f2)
 
@@ -37,7 +37,7 @@ cd apps
 file="./api/tag_value.yaml"
 IMAGE_TAG=""
 if [ "$target" = "dev" ]; then
-  get_image_hash "swissgeol_api"
+  get_image_hash "swissgeol-viewer-app-api"
   IMAGE_TAG=$VERSION@$retval
 elif [[ "$target" = "prod" || "$target" = "int" ]]; then
   IMAGE_TAG=$VERSION

--- a/scripts/deploy_viewer.sh
+++ b/scripts/deploy_viewer.sh
@@ -4,7 +4,7 @@ INT_BUCKET="ngmpub-int-bgdi-ch"
 DEV_BUCKET="ngmpub-dev-bgdi-ch"
 RELEASES_BUCKET="ngmpub-releases-bgdi-ch"
 PROD_BUCKET="ngmpub-prod-viewer-bgdi-ch"
-IMAGE_NAME="camptocamp/swissgeol_api"
+IMAGE_NAME="ghcr.io/swisstopo/swissgeol-viewer-app-api"
 
 
 if [[ "$1" == "dev" ]]

--- a/scripts/release_api.sh
+++ b/scripts/release_api.sh
@@ -4,7 +4,7 @@ os=$1 # mac for macos and empty for linux
 
 cd api
 
-IMAGE_NAME="camptocamp/swissgeol_api"
+IMAGE_NAME="ghcr.io/swisstopo/swissgeol-viewer-app-api"
 
 if [[ -z "${VERSION}" ]]
 then


### PR DESCRIPTION
1. Updated name for API docker image from docker hub one (camptocamp/swissgeol_api) to github repository (ghcr.io/swisstopo/swissgeol-viewer-app-api)
2. Updated readme