### PR TITLE
Reduce bottom-rule for disclaimer-link

### DIFF
--- a/ui/src/style/index.css
+++ b/ui/src/style/index.css
@@ -518,7 +518,7 @@ ngm-voxel-filter .ngm-action-btn.ui.button {
 }
 
 .disclaimer-link {
-  bottom: 40px;
+  bottom: 20px;
 }
 
 .contact-mailto-link:hover, .disclaimer-link:hover {


### PR DESCRIPTION
"bottom" for disclaimer-link class changed to 20px. IT-text overplapped contact-link

https://camptocamp.atlassian.net/browse/GSNGM-1203 