### PR TITLE
Fix 1348: Layerrreihenfolge nach Reload

### DIFF
--- a/ui/src/elements/ngm-side-bar.ts
+++ b/ui/src/elements/ngm-side-bar.ts
@@ -468,6 +468,9 @@ export class SideBar extends LitElementI18n {
           this.accordionInited = true;
         }
       }
+      if (changedProperties.has('activeLayers')) {
+        this.layerActions!.reorderLayers(this.activeLayers);
+      }
     }
 
     super.updated(changedProperties);


### PR DESCRIPTION
resolves #1348 

To test, use this [Link](http://localhost:8000/?lang=de&lon=7.99597&lat=46.87756&elevation=425658&heading=0&pitch=-90&map=ch.swisstopo.pixelkarte-grau&map_transparency=0.00&layers=ch.swisstopo.geologie-geocover%2Cch.swisstopo.swissalti3d-reliefschattierung%2Cch.swisstopo.geologie-geophysik-geothermie&layers_visibility=true%2Ctrue%2Ctrue&layers_transparency=0.00%2C0.00%2C0.00&layers_timestamp=current%2Ccurrent%2Ccurrent&maximumScreenSpaceError=4) 

This is based on #1353 and should thus be reviewed after it has been merged