### PR TITLE
Fix: Missing GST URL

### DIFF
--- a/k8s/templates/deployment.api.yaml
+++ b/k8s/templates/deployment.api.yaml
@@ -77,5 +77,9 @@ spec:
           - name: ION_DEFAULT_ACCESS_TOKEN
             value: "{{ .Values.ion.default_access_token }}"
 
+          # GST
+          - name: GST_URL
+            value: "{{ .Values.gst_url }}"
+
       imagePullSecrets:
       - name: {{ .Release.Namespace }}-registry

--- a/k8s/values.template.yaml
+++ b/k8s/values.template.yaml
@@ -24,3 +24,5 @@ cognito:
 
 ion:
   default_access_token:
+
+gst_url:


### PR DESCRIPTION
Add `gst_url` to k8s deployment