### PR TITLE
Feature 1474: Übersetzungen aktuelle Entwicklungen

### DIFF
--- a/ui/src/features/core/base/core-base-popup.element.ts
+++ b/ui/src/features/core/base/core-base-popup.element.ts
@@ -144,7 +144,11 @@ export abstract class CoreBasePopup<
     }
     this.updatePosition({ allowViewportCheck: true });
     assignedNodes.forEach((node) => {
-      box.appendChild(node);
+      if (node instanceof Text) {
+        box.appendChild(node.cloneNode(true));
+      } else {
+        box.appendChild(node);
+      }
     });
     this.updatePosition({ allowViewportCheck: true });
   }


### PR DESCRIPTION
Fixes an issue where translated text within popups is not updated when changing between languages.

This was caused by Lit not supporting manually moving dynamically generated text nodes.
When updating such a node, Lit expected it to be at its original place, which caused an error.
The fix for this is that we now just clone text nodes into popups instead of moving them, which solves this issue, while still keeping reactivity intact.