### PR TITLE
Fix translated text in dropdowns not being updated

### DIFF
--- a/ui/src/features/core/base/core-base-popup-box.element.ts
+++ b/ui/src/features/core/base/core-base-popup-box.element.ts
@@ -2,6 +2,8 @@ import { css, html, LitElement } from 'lit';
 import { applyTransition } from 'src/styles/theme';
 
 export abstract class CoreBasePopupBox extends LitElement {
+  private timeoutForToggle: unknown = null;
+
   protected constructor() {
     super();
     this.show = this.show.bind(this);
@@ -9,20 +11,28 @@ export abstract class CoreBasePopupBox extends LitElement {
   }
 
   show(): void {
+    this.clearToggle();
     this.classList.remove('is-hidden');
-    setTimeout(() => {
+    this.timeoutForToggle = setTimeout(() => {
       this.classList.add('is-visible');
     });
   }
 
   hide(): void {
+    this.clearToggle();
     this.classList.remove('is-visible');
-    setTimeout(() => {
+    this.timeoutForToggle = setTimeout(() => {
       this.classList.add('is-hidden');
     }, 250);
   }
 
-  readonly render = () => html``;
+  private clearToggle(): void {
+    if (this.timeoutForToggle !== null) {
+      clearTimeout(this.timeoutForToggle as number);
+    }
+  }
+
+  readonly render = () => html`<slot></slot>`;
 
   static readonly styles = css`
     :host,

--- a/ui/src/features/core/core-dropdown.element.ts
+++ b/ui/src/features/core/core-dropdown.element.ts
@@ -1,6 +1,9 @@
 import { css, html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { CoreBasePopup } from 'src/features/core/base/core-base-popup.element';
+import {
+  CoreBasePopup,
+  PopupProps,
+} from 'src/features/core/base/core-base-popup.element';
 import { CoreDropdownBox } from 'src/features/core/core-dropdown-box.element';
 import { CoreButton } from 'src/features/core/core-button.element';
 import { Subject, Subscription } from 'rxjs';
@@ -57,6 +60,7 @@ export class CoreDropdown extends CoreBasePopup<CoreDropdownBox> {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.subscription?.unsubscribe();
+    this.subscription = null;
   }
 
   override show(event?: Event): void {
@@ -77,17 +81,23 @@ export class CoreDropdown extends CoreBasePopup<CoreDropdownBox> {
     }
   }
 
-  readonly findBoxElement = () => {
-    return this.shadowRoot!.querySelector(
-      'ngm-core-dropdown-box',
-    )! as CoreDropdownBox;
-  };
-
-  readonly renderBox = () => html`
-    <ngm-core-dropdown-box></ngm-core-dropdown-box>
-  `;
-
   static readonly styles = css`
     ${CoreBasePopup.styles}
   `;
+}
+
+export function dropdown(content: unknown): unknown;
+export function dropdown(props: PopupProps, content: unknown): unknown;
+export function dropdown(
+  propsOrContent: unknown,
+  contentOrNone?: unknown,
+): unknown {
+  const content = contentOrNone ?? propsOrContent;
+  const props =
+    contentOrNone === undefined ? {} : (propsOrContent as PopupProps);
+  return html` <ngm-core-dropdown
+    .position="${props.position}"
+    .align="${props.align}"
+    .content="${content}"
+  ></ngm-core-dropdown>`;
 }

--- a/ui/src/features/core/core-element.element.ts
+++ b/ui/src/features/core/core-element.element.ts
@@ -8,10 +8,11 @@ export class CoreElement extends LitElement {
   @state()
   private accessor language!: string;
 
-  private readonly _subscription = new Subscription();
+  private _subscription = new Subscription();
 
   connectedCallback() {
     const handleLanguageChanged = (language) => {
+      this.willChangeLanguage(language);
       this.language = language;
     };
     i18next.on('languageChanged', handleLanguageChanged);
@@ -25,6 +26,7 @@ export class CoreElement extends LitElement {
   disconnectedCallback() {
     super.disconnectedCallback();
     this._subscription.unsubscribe();
+    this._subscription = new Subscription();
   }
 
   willUpdate(_changedProperties: PropertyValues): void {
@@ -34,6 +36,10 @@ export class CoreElement extends LitElement {
   }
 
   willFirstUpdate(): void {
+    /* Empty method to be implemented by child classes. */
+  }
+
+  willChangeLanguage(_language: void) {
     /* Empty method to be implemented by child classes. */
   }
 

--- a/ui/src/features/core/core-tooltip.element.ts
+++ b/ui/src/features/core/core-tooltip.element.ts
@@ -1,6 +1,9 @@
 import { html } from 'lit';
 import { customElement } from 'lit/decorators.js';
-import { CoreBasePopup } from 'src/features/core/base/core-base-popup.element';
+import {
+  CoreBasePopup,
+  PopupProps,
+} from 'src/features/core/base/core-base-popup.element';
 import { CoreTooltipBox } from 'src/features/core/core-tooltip-box.element';
 
 @customElement('ngm-core-tooltip')
@@ -23,11 +26,20 @@ export class CoreTooltip extends CoreBasePopup<CoreTooltipBox> {
       'pointerup',
     ];
   }
+}
 
-  readonly findBoxElement = () =>
-    this.shadowRoot!.querySelector('ngm-core-tooltip-box')! as CoreTooltipBox;
-
-  readonly renderBox = () => html`
-    <ngm-core-tooltip-box></ngm-core-tooltip-box>
-  `;
+export function tooltip(content: unknown): unknown;
+export function tooltip(props: PopupProps, content: unknown): unknown;
+export function tooltip(
+  propsOrContent: unknown,
+  contentOrNone?: unknown,
+): unknown {
+  const content = contentOrNone ?? propsOrContent;
+  const props =
+    contentOrNone === undefined ? {} : (propsOrContent as PopupProps);
+  return html`<ngm-core-tooltip
+    .position="${props.position}"
+    .align="${props.align}"
+    .content="${content}"
+  ></ngm-core-tooltip>`;
 }

--- a/ui/src/features/core/index.ts
+++ b/ui/src/features/core/index.ts
@@ -1,2 +1,5 @@
 export * from './core-element.element';
 export * from './core-modal.element';
+
+export { dropdown } from './core-dropdown.element';
+export { tooltip } from './core-tooltip.element';

--- a/ui/src/features/layer/display/layer-display-list-item.element.ts
+++ b/ui/src/features/layer/display/layer-display-list-item.element.ts
@@ -3,7 +3,7 @@ import { css, html } from 'lit';
 import { applyTransition, applyTypography } from 'src/styles/theme';
 import { SliderChangeEvent } from 'src/features/core/core-slider.element';
 import { classMap } from 'lit/directives/class-map.js';
-import { CoreElement } from 'src/features/core';
+import { CoreElement, dropdown, tooltip } from 'src/features/core';
 import { LayerConfig, LayerType } from 'src/layertree';
 import MainStore from 'src/store/main';
 import { Entity, Viewer } from 'cesium';
@@ -203,7 +203,7 @@ export class LayerDisplayListItem extends CoreElement {
         >
           ${Math.round(this.opacity * 100)}%
         </ngm-core-button>
-        <ngm-core-tooltip>${i18next.t('dtd_opacity')}</ngm-core-tooltip>
+        ${tooltip(i18next.t('dtd_opacity'))}
         ${this.layer == null ? '' : this.renderActions()}
       </div>
     </div>
@@ -229,7 +229,7 @@ export class LayerDisplayListItem extends CoreElement {
     >
       <ngm-core-icon icon="menu"></ngm-core-icon>
     </ngm-core-button>
-    <ngm-core-dropdown>
+    ${dropdown(html`
       <ngm-core-dropdown-item role="button" @click="${this.zoomToLayer}">
         <ngm-core-icon icon="zoomPlus"></ngm-core-icon>
         ${i18next.t('dtd_zoom_to')}
@@ -292,7 +292,7 @@ export class LayerDisplayListItem extends CoreElement {
         <ngm-core-icon icon="trash"></ngm-core-icon>
         ${i18next.t('dtd_remove')}
       </ngm-core-dropdown-item>
-    </ngm-core-dropdown>
+    `)}
   `;
 
   private readonly renderOpacity = () => html`

--- a/ui/src/features/layer/display/layer-display-list.element.ts
+++ b/ui/src/features/layer/display/layer-display-list.element.ts
@@ -69,7 +69,12 @@ export class LayerDisplayList extends CoreElement {
     }
   }
 
+  willChangeLanguage(): void {
+    this.initializeDragging();
+  }
+
   disconnectedCallback(): void {
+    super.disconnectedCallback();
     this.sortable?.destroy();
   }
 


### PR DESCRIPTION
Fixes an issue where translations in dropdowns was not being updated.
The problem was that the dropdowns were within a draggable element, which, after having been moved, caused the dropdown to loose its reactivity.

Also solves the issue where dropdowns were sometimes losing their content.
This had a similar reason, as Lit removed and re-added some elements containing dropdowns,
which destroyed the contents.