### PR TITLE
Feature 1434: Versions-nr. im Header anzeigen

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -7,6 +7,7 @@
 
 # Application
 APP_PORT=3000
+APP_VERSION=0.0.0-local
 ENV=dev
 
 # Database

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -5,10 +5,13 @@ use serde::Serialize;
 pub struct Config {
     #[clap(flatten)]
     pub database: Database,
+
     #[clap(long, env)]
     pub app_port: u16,
+
     #[clap(flatten)]
     pub auth: Auth,
+
     #[clap(long, env)]
     pub env: String,
 }
@@ -18,10 +21,17 @@ pub struct Config {
 pub struct ClientConfig {
     #[clap(long, env)]
     pub env: String,
+
+    #[clap(long, env)]
+    #[arg(env = "APP_VERSION")]
+    pub version: String,
+
     #[clap(long, env)]
     pub ion_default_access_token: String,
+
     #[clap(long, env)]
     pub gst_url: String,
+
     #[clap(flatten)]
     pub auth: Auth,
 }

--- a/ui/src/api/client-config.ts
+++ b/ui/src/api/client-config.ts
@@ -1,5 +1,6 @@
 export interface ClientConfig {
   env: 'dev' | 'int' | 'prod';
+  version: string;
   ionDefaultAccessToken: string;
   gstUrl: string;
   auth: {

--- a/ui/src/features/layout/layout-version-tag.element.ts
+++ b/ui/src/features/layout/layout-version-tag.element.ts
@@ -1,0 +1,22 @@
+import { CoreElement } from 'src/features/core';
+import { customElement } from 'lit/decorators.js';
+import { consume } from '@lit/context';
+import { clientConfigContext } from 'src/context';
+import { ClientConfig } from 'src/api/client-config';
+import { css } from 'lit';
+import { applyTypography } from 'src/styles/theme';
+
+@customElement('ngm-layout-version-tag')
+export class LayoutVersionTag extends CoreElement {
+  @consume({ context: clientConfigContext })
+  accessor clientConfig!: ClientConfig;
+
+  readonly render = () => this.clientConfig.version;
+
+  static readonly styles = css`
+    :host {
+      ${applyTypography('overline')}
+      color: var(--color-text--disabled);
+    }
+  `;
+}

--- a/ui/src/features/layout/layout.module.ts
+++ b/ui/src/features/layout/layout.module.ts
@@ -1,2 +1,3 @@
 import './layout-consent-modal.element';
 import './layout-language-selector.element';
+import './layout-version-tag.element';

--- a/ui/src/ngm-app.ts
+++ b/ui/src/ngm-app.ts
@@ -593,6 +593,7 @@ export class NgmApp extends LitElementI18n {
             class="hidden-mobile"
             .viewer="${this.viewer}"
           ></ngm-cursor-information>
+          <ngm-layout-version-tag></ngm-layout-version-tag>
           <ngm-layout-language-selector></ngm-layout-language-selector>
           <ngm-auth
             class="ngm-user"


### PR DESCRIPTION
Resolves #1434.

Note that the build workflows already fully support the `APP_VERSION` environment variable, so no change is needed there.